### PR TITLE
Minor: Add markdown comments to funccall `get_schema()` tests

### DIFF
--- a/01_funccall.ipynb
+++ b/01_funccall.ipynb
@@ -1050,6 +1050,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "369320d4",
+   "metadata": {},
+   "source": [
+    "### Additional `get_schema()` Test Cases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a8052380",
    "metadata": {},
    "source": [

--- a/01_funccall.ipynb
+++ b/01_funccall.ipynb
@@ -1049,6 +1049,92 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a8052380",
+   "metadata": {},
+   "source": [
+    "Union types are approximately mapped to JSON schema 'anyOf' with two or more value types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fc1d6f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': '_union_test',\n",
+       " 'description': 'Mandatory docstring',\n",
+       " 'input_schema': {'type': 'object',\n",
+       "  'properties': {'opt_tup': {'type': 'object',\n",
+       "    'description': '',\n",
+       "    'default': None,\n",
+       "    'anyOf': [{'type': 'array'}, {'type': 'string'}, {'type': 'integer'}]}},\n",
+       "  'title': None}}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def _union_test(opt_tup: Union[Tuple[int, int], str, int]=None):\n",
+    "    \"Mandatory docstring\"\n",
+    "    return \"\"\n",
+    "get_schema(_union_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7641aca8",
+   "metadata": {},
+   "source": [
+    "The new (Python 3.10+) union syntax can also be used, producing an equivalent schema."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1a11b3b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': '_new_union_test',\n",
+       " 'description': 'Mandatory docstring',\n",
+       " 'input_schema': {'type': 'object',\n",
+       "  'properties': {'opt_tup': {'type': 'object',\n",
+       "    'description': '',\n",
+       "    'default': None,\n",
+       "    'anyOf': [{'type': 'array'}, {'type': 'string'}, {'type': 'integer'}]}},\n",
+       "  'title': None}}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def _new_union_test(opt_tup: Tuple[int, int] | str | int =None):\n",
+    "    \"Mandatory docstring\"\n",
+    "    pass\n",
+    "get_schema(_new_union_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d24cc0a",
+   "metadata": {},
+   "source": [
+    "Optional is a special case of union types, limited to two types, one of which is None (mapped to null in JSON schema):"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "ac8f3d19",
@@ -1058,7 +1144,7 @@
      "data": {
       "text/plain": [
        "{'name': '_optional_test',\n",
-       " 'description': 'Schema test for Optional / Union\\n\\nReturns:\\n- type: string',\n",
+       " 'description': 'Mandatory docstring',\n",
        " 'input_schema': {'type': 'object',\n",
        "  'properties': {'opt_tup': {'type': 'object',\n",
        "    'description': '',\n",
@@ -1073,100 +1159,18 @@
     }
    ],
    "source": [
-    "def _optional_test(opt_tup: Optional[Tuple[int, int]]=None) -> str:\n",
-    "    \"Schema test for Optional / Union\"\n",
-    "    return \"\"\n",
+    "def _optional_test(opt_tup: Optional[Tuple[int, int]]=None):\n",
+    "    \"Mandatory docstring\"\n",
+    "    pass\n",
     "get_schema(_optional_test)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "825769a5",
+   "cell_type": "markdown",
+   "id": "c969721b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'name': '_union_test',\n",
-       " 'description': 'Schema test for Union\\n\\nReturns:\\n- type: string',\n",
-       " 'input_schema': {'type': 'object',\n",
-       "  'properties': {'opt_tup': {'type': 'array',\n",
-       "    'description': '',\n",
-       "    'items': {'type': 'integer'},\n",
-       "    'default': None}},\n",
-       "  'title': None}}"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "def _union_test(opt_tup: Union[Tuple[int, int]]=None) -> str:\n",
-    "    \"Schema test for Union\"\n",
-    "    return \"\"\n",
-    "get_schema(_union_test)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "df9b9d13",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'name': '_new_union_test',\n",
-       " 'description': 'Schema test for Union with the > 3.10 syntax\\n\\nReturns:\\n- type: string',\n",
-       " 'input_schema': {'type': 'object',\n",
-       "  'properties': {'opt_tup': {'type': 'object',\n",
-       "    'description': '',\n",
-       "    'default': None}},\n",
-       "  'title': None}}"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "def _new_union_test(opt_tup: str | None =None) -> str:\n",
-    "    \"Schema test for Union with the > 3.10 syntax\"\n",
-    "    return \"\"\n",
-    "get_schema(_new_union_test)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41ad5756",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'name': '_none_test',\n",
-       " 'description': 'Schema test for NoneType.',\n",
-       " 'input_schema': {'type': 'object',\n",
-       "  'properties': {'none': {'type': 'null', 'description': ''}},\n",
-       "  'title': None,\n",
-       "  'required': ['none']}}"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "def _none_test(none: type(None)):\n",
-    "    \"Schema test for NoneType.\"\n",
-    "    pass\n",
-    "get_schema(_none_test)"
+    "Containers can also be used, both in their parameterized form (`List[int]`) or as their unparameterized raw type (`List`). In the latter case, the item type is mapped to `object` in JSON schema."
    ]
   },
   {
@@ -1179,7 +1183,7 @@
      "data": {
       "text/plain": [
        "{'name': '_list_test',\n",
-       " 'description': 'Schema test for List\\n\\nReturns:\\n- type: string',\n",
+       " 'description': 'Mandatory docstring',\n",
        " 'input_schema': {'type': 'object',\n",
        "  'properties': {'l': {'type': 'array',\n",
        "    'description': '',\n",
@@ -1194,9 +1198,9 @@
     }
    ],
    "source": [
-    "def _list_test(l: List[int]) -> str:\n",
-    "    \"Schema test for List\"\n",
-    "    return \"\"\n",
+    "def _list_test(l: List[int]):\n",
+    "    \"Mandatory docstring\"\n",
+    "    pass\n",
     "get_schema(_list_test)"
    ]
   },
@@ -1210,7 +1214,7 @@
      "data": {
       "text/plain": [
        "{'name': '_raw_list_test',\n",
-       " 'description': 'Schema test for List\\n\\nReturns:\\n- type: string',\n",
+       " 'description': 'Mandatory docstring',\n",
        " 'input_schema': {'type': 'object',\n",
        "  'properties': {'l': {'type': 'array',\n",
        "    'description': '',\n",
@@ -1225,10 +1229,18 @@
     }
    ],
    "source": [
-    "def _raw_list_test(l: List) -> str:\n",
-    "    \"Schema test for List\"\n",
-    "    return \"\"\n",
+    "def _raw_list_test(l: List):\n",
+    "    \"Mandatory docstring\"\n",
+    "    pass\n",
     "get_schema(_raw_list_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5704c197",
+   "metadata": {},
+   "source": [
+    "The same applies to dictionary, which can similarly be parameterized with key/value types or specified as a raw type."
    ]
   },
   {
@@ -1241,7 +1253,7 @@
      "data": {
       "text/plain": [
        "{'name': '_dict_test',\n",
-       " 'description': 'Schema test for Dict.',\n",
+       " 'description': 'Mandatory docstring',\n",
        " 'input_schema': {'type': 'object',\n",
        "  'properties': {'d': {'type': 'object',\n",
        "    'description': '',\n",
@@ -1256,8 +1268,8 @@
     }
    ],
    "source": [
-    "def _dict_test(d: Dict[int, int]):\n",
-    "    \"Schema test for Dict.\"\n",
+    "def _dict_test(d: Dict[str, int]):\n",
+    "    \"Mandatory docstring\"\n",
     "    pass\n",
     "get_schema(_dict_test)"
    ]
@@ -1272,7 +1284,7 @@
      "data": {
       "text/plain": [
        "{'name': '_raw_dict_test',\n",
-       " 'description': 'Schema test for Dict.',\n",
+       " 'description': 'Mandatory docstring',\n",
        " 'input_schema': {'type': 'object',\n",
        "  'properties': {'d': {'type': 'object', 'description': ''}},\n",
        "  'title': None,\n",
@@ -1286,8 +1298,7 @@
    ],
    "source": [
     "def _raw_dict_test(d: Dict):\n",
-    "    \"Schema test for Dict.\"\n",
-    "    pass\n",
+    "    \"Mandatory docstring\"\n",
     "get_schema(_raw_dict_test)"
    ]
   },

--- a/toolslm/funccall.py
+++ b/toolslm/funccall.py
@@ -112,11 +112,11 @@ def PathArg(
     path: str  # A filesystem path
 ): return Path(path)
 
-# %% ../01_funccall.ipynb 65
+# %% ../01_funccall.ipynb 66
 import ast, time, signal, traceback
 from fastcore.utils import *
 
-# %% ../01_funccall.ipynb 66
+# %% ../01_funccall.ipynb 67
 def _copy_loc(new, orig):
     "Copy location information from original node to new node and all children."
     new = ast.copy_location(new, orig)
@@ -125,7 +125,7 @@ def _copy_loc(new, orig):
         elif isinstance(o, list): setattr(new, field, [_copy_loc(value, orig) for value in o])
     return new
 
-# %% ../01_funccall.ipynb 68
+# %% ../01_funccall.ipynb 69
 def _run(code:str ):
     "Run `code`, returning final expression (similar to IPython)"
     tree = ast.parse(code)
@@ -148,7 +148,7 @@ def _run(code:str ):
     if _result is not None: return _result
     return stdout_buffer.getvalue().strip()
 
-# %% ../01_funccall.ipynb 73
+# %% ../01_funccall.ipynb 74
 def python(code, # Code to execute
            timeout=5 # Maximum run time in seconds before a `TimeoutError` is raised
           ): # Result of last node, if it's an expression, or `None` otherwise
@@ -161,7 +161,7 @@ def python(code, # Code to execute
     except Exception as e: return traceback.format_exc()
     finally: signal.alarm(0)
 
-# %% ../01_funccall.ipynb 80
+# %% ../01_funccall.ipynb 81
 def mk_ns(*funcs_or_objs):
     merged = {}
     for o in funcs_or_objs:
@@ -170,7 +170,7 @@ def mk_ns(*funcs_or_objs):
         if callable(o) and hasattr(o, '__name__'): merged |= {o.__name__: o}
     return merged
 
-# %% ../01_funccall.ipynb 89
+# %% ../01_funccall.ipynb 90
 def call_func(fc_name, fc_inputs, ns):
     "Call the function `fc_name` with the given `fc_inputs` using namespace `ns`."
     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)

--- a/toolslm/funccall.py
+++ b/toolslm/funccall.py
@@ -112,11 +112,11 @@ def PathArg(
     path: str  # A filesystem path
 ): return Path(path)
 
-# %% ../01_funccall.ipynb 61
+# %% ../01_funccall.ipynb 65
 import ast, time, signal, traceback
 from fastcore.utils import *
 
-# %% ../01_funccall.ipynb 62
+# %% ../01_funccall.ipynb 66
 def _copy_loc(new, orig):
     "Copy location information from original node to new node and all children."
     new = ast.copy_location(new, orig)
@@ -125,7 +125,7 @@ def _copy_loc(new, orig):
         elif isinstance(o, list): setattr(new, field, [_copy_loc(value, orig) for value in o])
     return new
 
-# %% ../01_funccall.ipynb 64
+# %% ../01_funccall.ipynb 68
 def _run(code:str ):
     "Run `code`, returning final expression (similar to IPython)"
     tree = ast.parse(code)
@@ -148,7 +148,7 @@ def _run(code:str ):
     if _result is not None: return _result
     return stdout_buffer.getvalue().strip()
 
-# %% ../01_funccall.ipynb 69
+# %% ../01_funccall.ipynb 73
 def python(code, # Code to execute
            timeout=5 # Maximum run time in seconds before a `TimeoutError` is raised
           ): # Result of last node, if it's an expression, or `None` otherwise
@@ -161,7 +161,7 @@ def python(code, # Code to execute
     except Exception as e: return traceback.format_exc()
     finally: signal.alarm(0)
 
-# %% ../01_funccall.ipynb 76
+# %% ../01_funccall.ipynb 80
 def mk_ns(*funcs_or_objs):
     merged = {}
     for o in funcs_or_objs:
@@ -170,7 +170,7 @@ def mk_ns(*funcs_or_objs):
         if callable(o) and hasattr(o, '__name__'): merged |= {o.__name__: o}
     return merged
 
-# %% ../01_funccall.ipynb 85
+# %% ../01_funccall.ipynb 89
 def call_func(fc_name, fc_inputs, ns):
     "Call the function `fc_name` with the given `fc_inputs` using namespace `ns`."
     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)


### PR DESCRIPTION
This (minor) PR:
- adds markdown notes to the get_schema() test functions
- slightly cleans up get_schema() test functions
Making this section of the notebbok slightly easier to externally consume.
