### PR TITLE
Fix markdown hierarchy parsing for arbitrary header levels

### DIFF
--- a/toolslm/md_hier.py
+++ b/toolslm/md_hier.py
@@ -127,7 +127,7 @@ Admin users management.
         assert result['Parent.Child'] == '## Child\nChild content.\n### Grandchild\nGrandchild content.'
         assert result['Parent.Child.Grandchild'] == '### Grandchild\nGrandchild content.'
 
-    def test_level2_siblings_levels():
+    def test_multiple_level2_siblings():
         md_content = "##Sib 1\n##Sib 2\n##Sib 3\n##Sib 4\n##Sib 5'"
         result = markdown_to_dict(md_content)
         assert 'Sib 1' in result
@@ -142,5 +142,5 @@ Admin users management.
     test_no_content()
     test_different_levels()
     test_parent_includes_subheadings()
-    test_level2_siblings_levels()
+    test_multiple_level2_siblings()
     print('tests passed')

--- a/toolslm/md_hier.py
+++ b/toolslm/md_hier.py
@@ -127,11 +127,20 @@ Admin users management.
         assert result['Parent.Child'] == '## Child\nChild content.\n### Grandchild\nGrandchild content.'
         assert result['Parent.Child.Grandchild'] == '### Grandchild\nGrandchild content.'
 
+    def test_level2_siblings_levels():
+        md_content = "##Sib 1\n##Sib 2\n##Sib 3\n##Sib 4\n##Sib 5'"
+        result = markdown_to_dict(md_content)
+        assert 'Sib 1' in result
+        assert 'Sib 2' in result
+        assert 'Sib 3' in result
+        assert 'Sib 4' in result
+        assert 'Sib 5' in result
+
     test_empty_content()
     test_special_characters()
     test_duplicate_headings()
     test_no_content()
     test_different_levels()
     test_parent_includes_subheadings()
+    test_level2_siblings_levels()
     print('tests passed')
-

--- a/toolslm/md_hier.py
+++ b/toolslm/md_hier.py
@@ -142,6 +142,5 @@ Admin users management.
     test_no_content()
     test_different_levels()
     test_parent_includes_subheadings()
-
     test_multiple_level2_siblings()
     print('tests passed')

--- a/toolslm/md_hier.py
+++ b/toolslm/md_hier.py
@@ -142,5 +142,6 @@ Admin users management.
     test_no_content()
     test_different_levels()
     test_parent_includes_subheadings()
+
     test_multiple_level2_siblings()
     print('tests passed')

--- a/toolslm/md_hier.py
+++ b/toolslm/md_hier.py
@@ -29,8 +29,9 @@ def markdown_to_dict(markdown_content):
 
     # Build the dictionary with hierarchical keys
     result,stack = {},[]
+    first_level = headings[0]['level']
     for h in headings:
-        stack = stack[:h['level'] - 1] + [clean_heading(h['text'])]
+        stack = stack[:h['level'] - first_level] + [clean_heading(h['text'])]
         key = '.'.join(stack)
         result[key] = h['content']
     return dict2obj(result)


### PR DESCRIPTION
## Issue
The markdown parsing had an incorrect assumption about header levels. The code was slicing the stack based on `h['level'] - 1`, which assumed headers always start at level 1. However, markdown documents often start at level 2 (##) or higher.

For example, with headers starting at level 2:
- First header (##): stack slice to index 1
- Next header (###): slice to index 2
- Next header (####): slice to index 3

This worked initially when the stack was empty, but caused incorrect nesting once the stack contained enough elements.

## Fix
Modified the stack slicing to be relative to the first header's level:
```python
first_level = headings[0]['level']
stack = stack[:h['level'] - first_level] # instead of h['level'] - 1
```
This ensures correct nesting regardless of what level the document starts with.