### PR TITLE
Optionally dont raise error on call_func

### DIFF
--- a/01_funccall.ipynb
+++ b/01_funccall.ipynb
@@ -1963,12 +1963,33 @@
    "outputs": [],
    "source": [
     "#| exports\n",
-    "async def call_func_async(fc_name, fc_inputs, ns):\n",
+    "# async def call_func_async(fc_name, fc_inputs, ns, raise_on_err=True):\n",
+    "#     \"Awaits the function `fc_name` with the given `fc_inputs` using namespace `ns`.\"\n",
+    "#     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)\n",
+    "#     func = ns[fc_name]\n",
+    "#     res = func(**fc_inputs)\n",
+    "#     if inspect.iscoroutine(res): res = await res\n",
+    "#     return res\n",
+    "\n",
+    "\n",
+    "# def call_func(fc_name, fc_inputs, ns, raise_on_err=True):\n",
+    "#     \"Call the function `fc_name` with the given `fc_inputs` using namespace `ns`.\"\n",
+    "#     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)\n",
+    "#     func = ns[fc_name]\n",
+    "#     try: return func(**fc_inputs)\n",
+    "#     except Exception as e:\n",
+    "#         if raise_on_err: raise e\n",
+    "#         else: return str(e)\n",
+    "\n",
+    "\n",
+    "async def call_func_async(fc_name, fc_inputs, ns, raise_on_err=True):\n",
     "    \"Awaits the function `fc_name` with the given `fc_inputs` using namespace `ns`.\"\n",
-    "    if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)\n",
-    "    func = ns[fc_name]\n",
-    "    res = func(**fc_inputs)\n",
-    "    if inspect.iscoroutine(res): res = await res\n",
+    "    res = call_func(fc_name, fc_inputs, ns, raise_on_err=raise_on_err)\n",
+    "    if inspect.iscoroutine(res):\n",
+    "        try: res = await res\n",
+    "        except Exception as e:\n",
+    "            if raise_on_err: raise e\n",
+    "            else: return str(e)\n",
     "    return res"
    ]
   },
@@ -1994,6 +2015,29 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91092ee9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_eq(await call_func_async('asums', {'a': 1, 'b': '2'}, ns=[asums], raise_on_err=False), \"unsupported operand type(s) for +: 'int' and 'str'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a06776cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ex = False\n",
+    "try: await call_func_async('asums', {'a': 1, 'b': '2'}, ns=[asums], raise_on_err=True)\n",
+    "except: ex = True\n",
+    "assert ex"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "94ec4289",
    "metadata": {},
@@ -2013,6 +2057,14 @@
     "from nbdev.doclinks import nbdev_export\n",
     "nbdev_export()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cf037e0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/01_funccall.ipynb
+++ b/01_funccall.ipynb
@@ -1844,7 +1844,7 @@
     "    try: return func(**fc_inputs)\n",
     "    except Exception as e:\n",
     "        if raise_on_err: raise e\n",
-    "        else: return str(e)"
+    "        else: return traceback.format_exc()"
    ]
   },
   {
@@ -1904,7 +1904,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_eq(call_func('subs', {'a': 1, 'b': '3'}, ns=mk_ns(d), raise_on_err=False), \"unsupported operand type(s) for -: 'int' and 'str'\")"
+    "assert \"unsupported operand type(s) for -: 'int' and 'str'\" in call_func('subs', {'a': 1, 'b': '3'}, ns=mk_ns(d), raise_on_err=False)"
    ]
   },
   {
@@ -1915,6 +1915,39 @@
    "outputs": [],
    "source": [
     "test_fail(call_func, args=['subs', {'a': 1, 'b': '3'}], kwargs={'ns': mk_ns(d)})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b19298ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%ai\n",
+    "How do I get the whole traceback of an error instead of just str(e) like above?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ec89b42",
+   "metadata": {},
+   "source": [
+    "To get the whole traceback of an error instead of just `str(e)`, you can use the `traceback` module, which you've already imported in your code. Modify the `call_func` function to capture and return the full traceback when an error occurs:\n",
+    "\n",
+    "```python\n",
+    "#| exports\n",
+    "def call_func(fc_name, fc_inputs, ns, raise_on_err=True):\n",
+    "    \"Call the function `fc_name` with the given `fc_inputs` using namespace `ns`.\"\n",
+    "    if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)\n",
+    "    func = ns[fc_name]\n",
+    "    try: return func(**fc_inputs)\n",
+    "    except Exception as e:\n",
+    "        if raise_on_err: raise e\n",
+    "        else: return traceback.format_exc()\n",
+    "```\n",
+    "\n",
+    "This replaces `str(e)` with `traceback.format_exc()`, which returns the full traceback as a string, including the error type, message, and the call stack that led to the error. This gives you much more context about where and why the error occurred."
    ]
   },
   {
@@ -1963,25 +1996,6 @@
    "outputs": [],
    "source": [
     "#| exports\n",
-    "# async def call_func_async(fc_name, fc_inputs, ns, raise_on_err=True):\n",
-    "#     \"Awaits the function `fc_name` with the given `fc_inputs` using namespace `ns`.\"\n",
-    "#     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)\n",
-    "#     func = ns[fc_name]\n",
-    "#     res = func(**fc_inputs)\n",
-    "#     if inspect.iscoroutine(res): res = await res\n",
-    "#     return res\n",
-    "\n",
-    "\n",
-    "# def call_func(fc_name, fc_inputs, ns, raise_on_err=True):\n",
-    "#     \"Call the function `fc_name` with the given `fc_inputs` using namespace `ns`.\"\n",
-    "#     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)\n",
-    "#     func = ns[fc_name]\n",
-    "#     try: return func(**fc_inputs)\n",
-    "#     except Exception as e:\n",
-    "#         if raise_on_err: raise e\n",
-    "#         else: return str(e)\n",
-    "\n",
-    "\n",
     "async def call_func_async(fc_name, fc_inputs, ns, raise_on_err=True):\n",
     "    \"Awaits the function `fc_name` with the given `fc_inputs` using namespace `ns`.\"\n",
     "    res = call_func(fc_name, fc_inputs, ns, raise_on_err=raise_on_err)\n",
@@ -1989,7 +2003,7 @@
     "        try: res = await res\n",
     "        except Exception as e:\n",
     "            if raise_on_err: raise e\n",
-    "            else: return str(e)\n",
+    "            else: return traceback.format_exc()\n",
     "    return res"
    ]
   },

--- a/01_funccall.ipynb
+++ b/01_funccall.ipynb
@@ -37,6 +37,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "aec123ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|hide\n",
+    "from fastcore.test import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "a9f43047",
    "metadata": {},
    "outputs": [],
@@ -1531,14 +1542,14 @@
      "output_type": "stream",
      "text": [
       "Traceback (most recent call last):\n",
-      "  File \"/var/folders/51/b2_szf2945n072c0vj2cyty40000gn/T/ipykernel_46879/2963369439.py\", line 14, in python\n",
+      "  File \"/var/folders/5c/jls7k26j1tq6l03cl_kvpnwh0000gn/T/ipykernel_97636/2963369439.py\", line 14, in python\n",
       "    try: return _run(code, glb, loc)\n",
       "                ^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/var/folders/51/b2_szf2945n072c0vj2cyty40000gn/T/ipykernel_46879/1858893181.py\", line 18, in _run\n",
+      "  File \"/var/folders/5c/jls7k26j1tq6l03cl_kvpnwh0000gn/T/ipykernel_97636/1858893181.py\", line 18, in _run\n",
       "    try: exec(compiled_code, glb, loc)\n",
       "         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "  File \"<ast>\", line 1, in <module>\n",
-      "  File \"/var/folders/51/b2_szf2945n072c0vj2cyty40000gn/T/ipykernel_46879/2963369439.py\", line 9, in handler\n",
+      "  File \"/var/folders/5c/jls7k26j1tq6l03cl_kvpnwh0000gn/T/ipykernel_97636/2963369439.py\", line 9, in handler\n",
       "    def handler(*args): raise TimeoutError()\n",
       "                        ^^^^^^^^^^^^^^^^^^^^\n",
       "TimeoutError\n",
@@ -1826,11 +1837,14 @@
    "outputs": [],
    "source": [
     "#| exports\n",
-    "def call_func(fc_name, fc_inputs, ns):\n",
+    "def call_func(fc_name, fc_inputs, ns, raise_on_err=True):\n",
     "    \"Call the function `fc_name` with the given `fc_inputs` using namespace `ns`.\"\n",
     "    if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)\n",
     "    func = ns[fc_name]\n",
-    "    return func(**fc_inputs)"
+    "    try: return func(**fc_inputs)\n",
+    "    except Exception as e:\n",
+    "        if raise_on_err: raise e\n",
+    "        else: return str(e)"
    ]
   },
   {
@@ -1859,7 +1873,7 @@
     }
    ],
    "source": [
-    "await call_func('sums', {'a': 1, 'b': 2}, ns=[sums])"
+    "call_func('sums', {'a': 1, 'b': 2}, ns=[sums])"
    ]
   },
   {
@@ -1880,7 +1894,27 @@
     }
    ],
    "source": [
-    "await call_func('subs', {'a': 1, 'b': 2}, ns=mk_ns(d))"
+    "call_func('subs', {'a': 1, 'b': 2}, ns=mk_ns(d))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c93c0ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_eq(call_func('subs', {'a': 1, 'b': '3'}, ns=mk_ns(d), raise_on_err=False), \"unsupported operand type(s) for -: 'int' and 'str'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85489c3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_fail(call_func, args=['subs', {'a': 1, 'b': '3'}], kwargs={'ns': mk_ns(d)})"
    ]
   },
   {
@@ -1979,14 +2013,6 @@
     "from nbdev.doclinks import nbdev_export\n",
     "nbdev_export()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "207f9715",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/toolslm/funccall.py
+++ b/toolslm/funccall.py
@@ -198,28 +198,9 @@ def call_func(fc_name, fc_inputs, ns, raise_on_err=True):
     try: return func(**fc_inputs)
     except Exception as e:
         if raise_on_err: raise e
-        else: return str(e)
+        else: return traceback.format_exc()
 
-# %% ../01_funccall.ipynb 104
-# async def call_func_async(fc_name, fc_inputs, ns, raise_on_err=True):
-#     "Awaits the function `fc_name` with the given `fc_inputs` using namespace `ns`."
-#     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)
-#     func = ns[fc_name]
-#     res = func(**fc_inputs)
-#     if inspect.iscoroutine(res): res = await res
-#     return res
-
-
-# def call_func(fc_name, fc_inputs, ns, raise_on_err=True):
-#     "Call the function `fc_name` with the given `fc_inputs` using namespace `ns`."
-#     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)
-#     func = ns[fc_name]
-#     try: return func(**fc_inputs)
-#     except Exception as e:
-#         if raise_on_err: raise e
-#         else: return str(e)
-
-
+# %% ../01_funccall.ipynb 106
 async def call_func_async(fc_name, fc_inputs, ns, raise_on_err=True):
     "Awaits the function `fc_name` with the given `fc_inputs` using namespace `ns`."
     res = call_func(fc_name, fc_inputs, ns, raise_on_err=raise_on_err)
@@ -227,5 +208,5 @@ async def call_func_async(fc_name, fc_inputs, ns, raise_on_err=True):
         try: res = await res
         except Exception as e:
             if raise_on_err: raise e
-            else: return str(e)
+            else: return traceback.format_exc()
     return res

--- a/toolslm/funccall.py
+++ b/toolslm/funccall.py
@@ -201,10 +201,31 @@ def call_func(fc_name, fc_inputs, ns, raise_on_err=True):
         else: return str(e)
 
 # %% ../01_funccall.ipynb 104
-async def call_func_async(fc_name, fc_inputs, ns):
+# async def call_func_async(fc_name, fc_inputs, ns, raise_on_err=True):
+#     "Awaits the function `fc_name` with the given `fc_inputs` using namespace `ns`."
+#     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)
+#     func = ns[fc_name]
+#     res = func(**fc_inputs)
+#     if inspect.iscoroutine(res): res = await res
+#     return res
+
+
+# def call_func(fc_name, fc_inputs, ns, raise_on_err=True):
+#     "Call the function `fc_name` with the given `fc_inputs` using namespace `ns`."
+#     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)
+#     func = ns[fc_name]
+#     try: return func(**fc_inputs)
+#     except Exception as e:
+#         if raise_on_err: raise e
+#         else: return str(e)
+
+
+async def call_func_async(fc_name, fc_inputs, ns, raise_on_err=True):
     "Awaits the function `fc_name` with the given `fc_inputs` using namespace `ns`."
-    if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)
-    func = ns[fc_name]
-    res = func(**fc_inputs)
-    if inspect.iscoroutine(res): res = await res
+    res = call_func(fc_name, fc_inputs, ns, raise_on_err=raise_on_err)
+    if inspect.iscoroutine(res):
+        try: res = await res
+        except Exception as e:
+            if raise_on_err: raise e
+            else: return str(e)
     return res

--- a/toolslm/funccall.py
+++ b/toolslm/funccall.py
@@ -11,10 +11,10 @@ from fastcore.docments import docments
 from typing import get_origin, get_args, Dict, List, Optional, Tuple, Union
 from types import UnionType
 
-# %% ../01_funccall.ipynb 3
+# %% ../01_funccall.ipynb 4
 empty = inspect.Parameter.empty
 
-# %% ../01_funccall.ipynb 11
+# %% ../01_funccall.ipynb 12
 def _types(t:type)->tuple[str,Optional[str]]:
     "Tuple of json schema type name and (if appropriate) array item name."
     if t is empty: raise TypeError('Missing type')
@@ -31,7 +31,7 @@ def _types(t:type)->tuple[str,Optional[str]]:
     # if t is the type itself like int, use the __name__ representation as the key
     else: return tmap.get(t.__name__, "object"), None
 
-# %% ../01_funccall.ipynb 18
+# %% ../01_funccall.ipynb 19
 def _param(name, info):
     "json schema parameter given `name` and `info` from docments full dict."
     paramt,itemt = _types(info.anno)
@@ -40,7 +40,7 @@ def _param(name, info):
     if info.default is not empty: pschema["default"] = info.default
     return pschema
 
-# %% ../01_funccall.ipynb 21
+# %% ../01_funccall.ipynb 22
 custom_types = {Path}
 
 def _handle_type(t, defs):
@@ -52,7 +52,7 @@ def _handle_type(t, defs):
         return {'$ref': f'#/$defs/{t.__name__}'}
     return {'type': _types(t)[0]}
 
-# %% ../01_funccall.ipynb 23
+# %% ../01_funccall.ipynb 24
 def _is_container(t):
     "Check if type is a container (list, dict, tuple, set, Union)"
     origin = get_origin(t)
@@ -62,7 +62,7 @@ def _is_parameterized(t):
     "Check if type has arguments (e.g. list[int] vs list, dict[str, int] vs dict)"
     return _is_container(t) and (get_args(t) != ())
 
-# %% ../01_funccall.ipynb 29
+# %% ../01_funccall.ipynb 30
 def _handle_container(origin, args, defs):
     "Handle container types like dict, list, tuple, set, and Union"
     if origin is Union or origin is UnionType:
@@ -83,7 +83,7 @@ def _handle_container(origin, args, defs):
         return schema
     return None
 
-# %% ../01_funccall.ipynb 30
+# %% ../01_funccall.ipynb 31
 def _process_property(name, obj, props, req, defs):
     "Process a single property of the schema"
     p = _param(name, obj)
@@ -96,7 +96,7 @@ def _process_property(name, obj, props, req, defs):
         # Non-container type or container without arguments
         p.update(_handle_type(obj.anno, defs))
 
-# %% ../01_funccall.ipynb 31
+# %% ../01_funccall.ipynb 32
 def _get_nested_schema(obj):
     "Generate nested JSON schema for a class or function"
     d = docments(obj, full=True)
@@ -111,7 +111,7 @@ def _get_nested_schema(obj):
     if defs: schema['$defs'] = defs
     return schema
 
-# %% ../01_funccall.ipynb 35
+# %% ../01_funccall.ipynb 36
 def get_schema(f:Union[callable,dict], pname='input_schema')->dict:
     "Generate JSON schema for a class, function, or method"
     if isinstance(f, dict): return f
@@ -123,16 +123,16 @@ def get_schema(f:Union[callable,dict], pname='input_schema')->dict:
     if ret.anno is not empty: desc += f'\n\nReturns:\n- type: {_types(ret.anno)[0]}'
     return {"name": f.__name__, "description": desc, pname: schema}
 
-# %% ../01_funccall.ipynb 46
+# %% ../01_funccall.ipynb 47
 def PathArg(
     path: str  # A filesystem path
 ): return Path(path)
 
-# %% ../01_funccall.ipynb 66
+# %% ../01_funccall.ipynb 67
 import ast, time, signal, traceback
 from fastcore.utils import *
 
-# %% ../01_funccall.ipynb 67
+# %% ../01_funccall.ipynb 68
 def _copy_loc(new, orig):
     "Copy location information from original node to new node and all children."
     new = ast.copy_location(new, orig)
@@ -141,7 +141,7 @@ def _copy_loc(new, orig):
         elif isinstance(o, list): setattr(new, field, [_copy_loc(value, orig) for value in o])
     return new
 
-# %% ../01_funccall.ipynb 69
+# %% ../01_funccall.ipynb 70
 def _run(code:str, glb:dict=None, loc:dict=None):
     "Run `code`, returning final expression (similar to IPython)"
     tree = ast.parse(code)
@@ -164,7 +164,7 @@ def _run(code:str, glb:dict=None, loc:dict=None):
     if _result is not None: return _result
     return stdout_buffer.getvalue().strip()
 
-# %% ../01_funccall.ipynb 74
+# %% ../01_funccall.ipynb 75
 def python(code:str, # Code to execute
            glb:Optional[dict]=None, # Globals namespace
            loc:Optional[dict]=None, # Locals namespace
@@ -181,7 +181,7 @@ def python(code:str, # Code to execute
     except Exception as e: return traceback.format_exc()
     finally: signal.alarm(0)
 
-# %% ../01_funccall.ipynb 85
+# %% ../01_funccall.ipynb 86
 def mk_ns(*funcs_or_objs):
     merged = {}
     for o in funcs_or_objs:
@@ -190,14 +190,17 @@ def mk_ns(*funcs_or_objs):
         if callable(o) and hasattr(o, '__name__'): merged |= {o.__name__: o}
     return merged
 
-# %% ../01_funccall.ipynb 94
-def call_func(fc_name, fc_inputs, ns):
+# %% ../01_funccall.ipynb 95
+def call_func(fc_name, fc_inputs, ns, raise_on_err=True):
     "Call the function `fc_name` with the given `fc_inputs` using namespace `ns`."
     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)
     func = ns[fc_name]
-    return func(**fc_inputs)
+    try: return func(**fc_inputs)
+    except Exception as e:
+        if raise_on_err: raise e
+        else: return str(e)
 
-# %% ../01_funccall.ipynb 101
+# %% ../01_funccall.ipynb 104
 async def call_func_async(fc_name, fc_inputs, ns):
     "Awaits the function `fc_name` with the given `fc_inputs` using namespace `ns`."
     if not isinstance(ns, abc.Mapping): ns = mk_ns(*ns)


### PR DESCRIPTION
Call_func can stop a tool loop even when a raise shouldn't stop execution.

For example claudette will halt when a tool is used incorrectly, like div (x, 0). This should go back to the agent to try again. Here we make raising vs passing the error trace optional.