### PR TITLE
Fix get_schema crash on dataclasses with None return annotation

### DIFF
--- a/01_funccall.ipynb
+++ b/01_funccall.ipynb
@@ -667,7 +667,7 @@
     "    assert desc, \"Docstring missing!\"\n",
     "    d = docments(f, full=True)\n",
     "    ret = d.pop('return')\n",
-    "    if ret.anno is not empty: desc += f'\\n\\nReturns:\\n- type: {_types(ret.anno)[0]}'\n",
+    "    if (ret.anno is not empty) and (ret.anno is not None): desc += f'\\n\\nReturns:\\n- type: {_types(ret.anno)[0]}'\n",
     "    return {\"name\": f.__name__, \"description\": desc, pname: schema}"
    ]
   },


### PR DESCRIPTION
Fixes #43 by treating None return annotations like empty return annotations. 