### PR TITLE
Add 'items' field to JSON schema for Gemini compatibility

### DIFF
--- a/01_funccall.ipynb
+++ b/01_funccall.ipynb
@@ -193,7 +193,7 @@
     "    if t is empty: raise TypeError('Missing type')\n",
     "    tmap = {int:\"integer\", float:\"number\", str:\"string\", bool:\"boolean\", list:\"array\", dict:\"object\"}\n",
     "    tmap.update({k.__name__: v for k, v in tmap.items()})\n",
-    "    if getattr(t, '__origin__', None) in (list,tuple):\n",
+    "    if getattr(t, '__origin__', None) in (list,tuple,set):\n",
     "        args = getattr(t, '__args__', None)\n",
     "        item_type = \"object\" if not args else tmap.get(t.__args__[0].__name__, \"object\")\n",
     "        return \"array\", item_type\n",
@@ -222,7 +222,10 @@
     {
      "data": {
       "text/plain": [
-       "(('array', 'integer'), ('integer', None), ('integer', None))"
+       "(('array', 'integer'),\n",
+       " ('array', 'integer'),\n",
+       " ('integer', None),\n",
+       " ('integer', None))"
       ]
      },
      "execution_count": null,
@@ -231,7 +234,7 @@
     }
    ],
    "source": [
-    "_types(list[int]), _types(int), _types('int')"
+    "_types(list[int]), _types(set[int]), _types(int), _types('int')"
    ]
   },
   {
@@ -435,9 +438,11 @@
     "\n",
     "def _handle_type(t, defs):\n",
     "    \"Handle a single type, creating nested schemas if necessary\"\n",
+    "    ot = ifnone(get_origin(t), t)\n",
     "    if t is NoneType: return {'type': 'null'}\n",
     "    if t in custom_types: return {'type':'string', 'format':t.__name__}\n",
-    "    if t in (dict, list, tuple, set): return {'type': _types(t)[0]}\n",
+    "    if ot is dict: return {'type': _types(t)[0]} \n",
+    "    if ot in (list, tuple, set): return {'type': _types(t)[0], 'items':{}}\n",
     "    if isinstance(t, type) and not issubclass(t, (int, float, str, bool)) or inspect.isfunction(t):\n",
     "        defs[t.__name__] = _get_nested_schema(t)\n",
     "        return {'$ref': f'#/$defs/{t.__name__}'}\n",
@@ -468,13 +473,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf33dc16",
+   "id": "a43e9134",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "({'type': 'array'}, {'type': 'array'})"
+       "({'type': 'array', 'items': {}},\n",
+       " {'type': 'array', 'items': {}},\n",
+       " {'type': 'array', 'items': {}})"
       ]
      },
      "execution_count": null,
@@ -484,7 +491,7 @@
    ],
    "source": [
     "# gemini expect `items` to be defined for arrays\n",
-    "_handle_type(list, None), _handle_type(list[str], None)"
+    "_handle_type(list, None), _handle_type(tuple[str], None), _handle_type(set[str], None)"
    ]
   },
   {


### PR DESCRIPTION
Gemini models assume that `items` are present for type: 'array'. Adding items: {} fixes the issue.

This prevents 400 Bad Request errors during tool registration. Otherwise, using Gemini with tools like `symfiles_package` results in an error. 