### PR TITLE
handle object type hint

### DIFF
--- a/01_funccall.ipynb
+++ b/01_funccall.ipynb
@@ -443,6 +443,7 @@
     "    if t is NoneType: return {'type': 'null'}\n",
     "    if t in custom_types: return {'type':'string', 'format':t.__name__}\n",
     "    if ot is dict: return {'type': _types(t)[0]} \n",
+    "    if t is object: return {'type': 'object'}\n",
     "    if ot in (list, tuple, set): return {'type': _types(t)[0], 'items':{}}\n",
     "    if isinstance(t, type) and not issubclass(t, (int, float, str, bool)) or inspect.isfunction(t):\n",
     "        defs[t.__name__] = _get_nested_schema(t)\n",

--- a/toolslm/funccall.py
+++ b/toolslm/funccall.py
@@ -63,6 +63,7 @@ def _handle_type(t, defs):
     if t is NoneType: return {'type': 'null'}
     if t in custom_types: return {'type':'string', 'format':t.__name__}
     if ot is dict: return {'type': _types(t)[0]} 
+    if t is object: return {'type': 'object'}
     if ot in (list, tuple, set): return {'type': _types(t)[0], 'items':{}}
     if isinstance(t, type) and not issubclass(t, (int, float, str, bool)) or inspect.isfunction(t):
         defs[t.__name__] = _get_nested_schema(t)


### PR DESCRIPTION
`_handle_type` crashes with `AttributeError: '_ParameterKind' object has no attribute '__name__'` when a parameter is annotated with `object`. Since `object` is a `type` and not a subclass of `(int, float, str, bool)`, it falls into the nested schema branch which tries to introspect `object.__init__` — causing the crash. Fixed by returning `{'type': 'object'}` early for the `object` type.

Fixes #75