### PR TITLE
Schema round trip: carry param descriptions as Annotated metadata; unwrap Annotated in handle_type

### DIFF
--- a/nbs/01_funccall.ipynb
+++ b/nbs/01_funccall.ipynb
@@ -29,8 +29,8 @@
     "import inspect, ast, keyword\n",
     "from collections import abc\n",
     "from fastcore.utils import *\n",
-    "from fastcore.docments import docments\n",
-    "from typing import get_origin, get_args, Optional, Union, Any\n",
+    "from fastcore.docments import docments, ann_parts\n",
+    "from typing import get_origin, get_args, Optional, Union, Any, Annotated\n",
     "from types import UnionType\n",
     "from typing import get_type_hints\n",
     "from inspect import Parameter, Signature\n",
@@ -332,6 +332,7 @@
     "#| export\n",
     "def handle_type(t, defs):\n",
     "    \"Convert a type annotation to JSON Schema\"\n",
+    "    t,_ = ann_parts(t)\n",
     "    if t is empty: raise TypeError(\"Missing type annotation\")\n",
     "    if t in (object, Any): raise TypeError(f\"Can't make a schema for {t!r}\")\n",
     "    ot = ifnone(get_origin(t), t)\n",
@@ -2551,6 +2552,7 @@
     "        item_type = type_map.get(props['items'].get('type'), Any)\n",
     "        anno = list[item_type]\n",
     "    else: anno = type_map.get(props.get('type'), Any)\n",
+    "    if (d := props.get('description')): anno = Annotated[anno, d]\n",
     "    return Parameter(pynm, kind, default=default, annotation=anno)"
    ]
   },
@@ -2821,6 +2823,27 @@
     "tool_collision = dict2obj(dict(name='run', description='Run command', inputSchema=dict(type='object', properties={'approval-policy': {'type': 'string'}, 'approval_policy': {'type': 'string'}})))\n",
     "\n",
     "test_fail(lambda: schema2sig(tool_collision), contains='collision')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb569d76",
+   "metadata": {},
+   "source": [
+    "A schema-derived function must be re-derivable: `get_schema` on `mk_tool`'s output reproduces the schema it was built from. This matters wherever a remote tool re-enters a local toolchain, e.g. an MCP client's bound tools passed to a chat API. Parameter descriptions ride on the rebuilt signature as `Annotated` metadata, which is how `docments` reads them back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a943d93c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rt_tool = dict2obj(dict(name='fahrenheit', description='Convert Celsius to Fahrenheit',\n",
+    "    inputSchema=dict(type='object', required=['celsius'],\n",
+    "        properties=dict(celsius=dict(description='Temperature to convert', type='number')))))\n",
+    "test_eq(get_schema(mk_tool(noop, rt_tool), pname='inputSchema'), dict(rt_tool))"
    ]
   },
   {

--- a/toolslm/funccall.py
+++ b/toolslm/funccall.py
@@ -10,8 +10,8 @@ __all__ = ['empty', 'custom_types', 'type_map', 'handle_type', 'union_schema', '
 import inspect, ast, keyword
 from collections import abc
 from fastcore.utils import *
-from fastcore.docments import docments
-from typing import get_origin, get_args, Optional, Union, Any
+from fastcore.docments import docments, ann_parts
+from typing import get_origin, get_args, Optional, Union, Any, Annotated
 from types import UnionType
 from typing import get_type_hints
 from inspect import Parameter, Signature
@@ -49,6 +49,7 @@ def _type_str(t):
 # %% ../nbs/01_funccall.ipynb #c141588b
 def handle_type(t, defs):
     "Convert a type annotation to JSON Schema"
+    t,_ = ann_parts(t)
     if t is empty: raise TypeError("Missing type annotation")
     if t in (object, Any): raise TypeError(f"Can't make a schema for {t!r}")
     ot = ifnone(get_origin(t), t)
@@ -305,6 +306,7 @@ def mk_param(orig, props, req, pynm=None):
         item_type = type_map.get(props['items'].get('type'), Any)
         anno = list[item_type]
     else: anno = type_map.get(props.get('type'), Any)
+    if (d := props.get('description')): anno = Annotated[anno, d]
     return Parameter(pynm, kind, default=default, annotation=anno)
 
 # %% ../nbs/01_funccall.ipynb #a8befff6


### PR DESCRIPTION
A schema-derived function should be re-derivable: `get_schema` on `mk_tool`'s output reproduces the schema it was built from. Today parameter descriptions are lost in the rebuild — noticed because an MCP client's bound tools (mcpmini rebuilds them via `mk_tool`) re-enter fastllm with empty param descriptions, which is exactly what a model reads when deciding what to pass.

Two defects, both fixed here:

- `mk_param` read type/default/required from the wire schema and dropped `description` (a `Parameter` has no docstring field). It now carries it as `Annotated[T, desc]`, which `docments` already reads.
- `handle_type` never unwrapped `Annotated`, so any `Annotated` parameter produced a junk type like `object[number, object]` — a latent bug independent of the round trip. It now unwraps via `ann_parts` before type mapping, so unions/lists/nested types all see the bare type.

New test asserts the whole round trip (`get_schema(mk_tool(noop, t)) == t`), red before the fix, green after; full `nbdev-test` passes.

Cost worth noting: `str(inspect.signature(...))` on rebuilt tools now shows the `Annotated` wrapper. AnswerDotAI/mcpmini has a one-test companion PR updating its byte-exact signature assertion to assert the round-trip property instead.